### PR TITLE
Add touchPointsEnabled property to allow toggling touch points display

### DIFF
--- a/NRWindow.h
+++ b/NRWindow.h
@@ -12,4 +12,8 @@
 
 @property (nonatomic, strong) UIImage *touchRepresentationCustomImage;
 
+@property (nonatomic) BOOL touchPointsEnabled;
+
+- (void)initDefaults;
+
 @end

--- a/NRWindow.m
+++ b/NRWindow.m
@@ -11,11 +11,32 @@
 
 @implementation NRWindow
 
+- (id)initWithFrame:(CGRect)frame
+{
+    if (self = [super initWithFrame:frame]) {
+        [self initDefaults];
+    }
+    return self;
+}
+
+- (id)initWithCoder:(NSCoder *)coder
+{
+    if (self = [super initWithCoder:coder]) {
+        [self initDefaults];
+    }
+    return self;
+}
+
+- (void)initDefaults
+{
+    [self setTouchPointsEnabled:YES];
+}
+
 - (void)sendEvent:(UIEvent *)event
 {
     [super sendEvent:event];
     
-    if (event.type == UIEventTypeTouches)
+    if (self.touchPointsEnabled && event.type == UIEventTypeTouches)
     {
         for (UITouch *touch in [event allTouches])
         {


### PR DESCRIPTION
This pull adds a property `touchPointsEnabled` to `NRWindow` to allow for programmatic toggling of the touch points behavior. Because all of the control is currently in the `sendEvent` method, I've had to reimplement the `sendEvent` to turn the behavior on/off within the app (or via app settings), this additional property allows for programmatic access, and makes it easy to change the default.
